### PR TITLE
chore(updatecli) enable automatic update of plugin versions used for test fixture data

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,32 @@
+---
+name: updatecli
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At the end of every day
+    - cron: '0 0 * * *'
+  push:
+  pull_request:
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Diff
+        uses: updatecli/updatecli-action@v1
+        with:
+          command: diff
+          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Apply
+        uses: updatecli/updatecli-action@v1
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+        with:
+          command: apply
+          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: updatecli/updatecli-action@v1
         with:
           command: diff
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
+          flags: "--config ./updatecli/daily.d --values ./updatecli/values.yaml"
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Apply
@@ -27,6 +27,6 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
         with:
           command: apply
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.yaml"
+          flags: "--config ./updatecli/daily.d --values ./updatecli/values.yaml"
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/daily.d/ansicolor.yaml
+++ b/updatecli/daily.d/ansicolor.yaml
@@ -1,0 +1,24 @@
+---
+title: Bump ansicolor version in test fixture data
+sources:
+  latestVersion:
+    kind: maven
+    spec:
+      url: "repo.jenkins-ci.org"
+      repository: "releases"
+      groupID: "org.jenkins-ci.plugins"
+      artifactID: "ansicolor"
+conditions:
+  checkForTestData:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: ./pkg/cmd/update_test.go
+      matchpattern: '// ansicolor:(.*)'
+targets:
+  updateTestData:
+    kind: file
+    spec:
+      file: ./pkg/cmd/update_test.go
+      matchpattern: '// ansicolor:(.*)'
+      replacepattern: '// ansicolor:{{ source `latestVersion` }}'

--- a/updatecli/daily.d/antisamy-markup-formatter.yaml
+++ b/updatecli/daily.d/antisamy-markup-formatter.yaml
@@ -1,0 +1,24 @@
+---
+title: Bump antisamy-markup-formatter version in test fixture data
+sources:
+  latestVersion:
+    kind: maven
+    spec:
+      url: "repo.jenkins-ci.org"
+      repository: "releases"
+      groupID: "org.jenkins-ci.plugins"
+      artifactID: "antisamy-markup-formatter"
+conditions:
+  checkForTestData:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: ./pkg/cmd/update_test.go
+      matchpattern: '// antisamy-markup-formatter:(.*)'
+targets:
+  updateTestData:
+    kind: file
+    spec:
+      file: ./pkg/cmd/update_test.go
+      matchpattern: '// antisamy-markup-formatter:(.*)'
+      replacepattern: '// antisamy-markup-formatter:{{ source `latestVersion` }}'

--- a/updatecli/daily.d/authentication-tokens.yaml
+++ b/updatecli/daily.d/authentication-tokens.yaml
@@ -1,0 +1,24 @@
+---
+title: Bump authentication-tokens version in test fixture data
+sources:
+  latestVersion:
+    kind: maven
+    spec:
+      url: "repo.jenkins-ci.org"
+      repository: "releases"
+      groupID: "org.jenkins-ci.plugins"
+      artifactID: "authentication-tokens"
+conditions:
+  checkForTestData:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: ./pkg/cmd/update_test.go
+      matchpattern: '// authentication-tokens:(.*)'
+targets:
+  updateTestData:
+    kind: file
+    spec:
+      file: ./pkg/cmd/update_test.go
+      matchpattern: '// authentication-tokens:(.*)'
+      replacepattern: '// authentication-tokens:{{ source `latestVersion` }}'


### PR DESCRIPTION
Tests are regularly failing when the plugins used as fixture data are upgraded:

```
--- FAIL: ExampleDisplayUpdatesFromPluginTxt (6.56s)
got:
ansicolor:1.0.1
antisamy-markup-formatter:2.5
authentication-tokens:1.4
want:
ansicolor:1.0.0
antisamy-markup-formatter:2.3
authentication-tokens:1.4
--- FAIL: ExampleDisplayUpdatesFromValuesYaml (6.42s)
got:
ansicolor:1.0.1
antisamy-markup-formatter:2.5
authentication-tokens:1.4
want:
ansicolor:1.0.0
antisamy-markup-formatter:2.3
authentication-tokens:1.4
```

This PR enables updatecli to keep the fixture data up to date and avoid such errors in the future.